### PR TITLE
Update msgpack library because of UInt64 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 var uid2 = require('uid2');
 var redis = require('redis').createClient;
-var msgpack = require('msgpack-js');
+var msgpack = require('msgpack5')();
 var Adapter = require('socket.io-adapter');
 var Emitter = require('events').EventEmitter;
 var debug = require('debug')('socket.io-redis');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "0.9.0",
     "debug": "2.2.0",
-    "msgpack-js": "0.3.0",
+    "msgpack5": "3.3.0",
     "redis": "2.4.2",
     "socket.io-adapter": "0.4.0",
     "uid2": "0.0.3"


### PR DESCRIPTION
Corrected dependencies: msgpack5 instead of msgpack-js

Emitting messages with external processes trigger errors on msgpack decoding of UInt64.
Detailed description can be found at https://github.com/creationix/msgpack-js/issues/16

The solution is very quick... change msgpack library which socket.io-redis is based on.
